### PR TITLE
Bugfix: Add authorization header to api calls

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,11 +8,9 @@ var endpoints = require('./api/slack.json');
 function slackWrapi(token) {
 
   var opts = {
-    qs: {
-      token: token
-    },
     headers: {
-      'User-Agent': 'slack-wrapi'
+      'User-Agent': 'slack-wrapi',
+      'Authorization': 'Bearer ' + token,
     }
   };
 


### PR DESCRIPTION
### Description
- For new apps, it is require to send the token via `Authorization` header. See changelog: https://api.slack.com/changelog/2020-11-no-more-tokens-in-querystrings-for-newly-created-apps
- This change is backwards compatible with legacy apps, as per the link above